### PR TITLE
Enhancement: Add function to remove authorized assessors

### DIFF
--- a/contracts/risk-oracle.clar
+++ b/contracts/risk-oracle.clar
@@ -75,6 +75,17 @@
   )
 )
 
+;; Remove authorized assessor - **New Enhancement**
+(define-public (revoke-assessor (assessor principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (ok (map-set authorized-assessors
+      { assessor: assessor }
+      { authorized: false, added-at: stacks-block-height }
+    ))
+  )
+)
+
 ;; Read-only functions
 
 ;; Get protocol risk score


### PR DESCRIPTION
Added a new revoke-assessor public function that allows the contract owner to deactivate an authorized assessor. This enhances security by enabling the owner to remove access from assessors who should no longer update protocol risk scores, while maintaining their record for auditing purposes.